### PR TITLE
[chore/refactor] Java 버전 다운그레이드 및 인증 시스템 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(23)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -38,11 +38,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
 
-    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-actuator
-    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.2.3'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
-    // https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.14.3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     testImplementation 'net.bytebuddy:byte-buddy:1.14.12'  // 최신 버전
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/example/global/config/WebConfig.java
+++ b/src/main/java/com/example/global/config/WebConfig.java
@@ -19,6 +19,9 @@ public class WebConfig implements WebMvcConfigurer {
 		registry
 			.addMapping("/**")
 			.allowedOrigins(
+				"https://tstube.shop",
+				"https://www.tstube.shop",
+				"http://tstube.shop",
 				"http://www.tstube.shop",
 				"http://www.xn----bv7eq1qhzbe7i6wn.shop", // 허용할 도메인 1
 				"http://localhost:3000"                  // 허용할 도메인 2,

--- a/src/main/java/com/example/security/CookieUtils.java
+++ b/src/main/java/com/example/security/CookieUtils.java
@@ -1,0 +1,55 @@
+package com.example.security;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import org.springframework.util.SerializationUtils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtils {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					cookie.setValue("");
+					cookie.setPath("/");
+					cookie.setMaxAge(0);
+					response.addCookie(cookie);
+				}
+			}
+		}
+	}
+
+	public static String serialize(Object object) {
+		return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+	}
+}

--- a/src/main/java/com/example/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/example/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,54 @@
+package com.example.security.oauth;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.example.security.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements
+	AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+	private static final int cookieExpireSeconds = 500;
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		OAuth2AuthorizationRequest oAuth2AuthorizationRequest =  CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+			.map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+			.orElse(null);
+		return oAuth2AuthorizationRequest;
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			removeAuthorizationRequest(request, response);
+			return;
+		}
+
+		CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+			CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+		}
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+		CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+	}
+
+}

--- a/src/main/java/com/example/security/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/example/security/oauth/OAuth2AuthenticationFailureHandler.java
@@ -3,22 +3,31 @@ package com.example.security.oauth;
 import java.io.IOException;
 
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
-public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
-		String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/login")
-				.queryParam("error", exception.getMessage())
-				.build().toUriString();
+
+		// 실패 시 OAuth2 인증 요청 쿠키 정리
+		httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+		String targetUrl = UriComponentsBuilder.fromUriString("http://www.tstube.shop/login")
+			.queryParam("error", exception.getMessage())
+			.build().toUriString();
 
 		response.sendRedirect(targetUrl);
 	}


### PR DESCRIPTION
## 변경 사항
- Java 버전 23에서 17로 다운그레이드
- 프로메테우스 및 actuator 버전 변경
- HTTPS 설정 및 CORS 해결
- OAuth2 세션 인증 방식에서 OAuth2/JWT 쿠키 기반 인증으로 전환

## 테스트 결과
- Java 17 환경에서 정상 동작 확인
- HTTPS 및 CORS 정상 작동 확인
- OAuth2/JWT 인증 플로우 정상 작동 확인
